### PR TITLE
Windows Console Titles

### DIFF
--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -2,12 +2,14 @@
 import platform
 from warnings import warn
 
-try:
-    from xonsh.jobs_posix import *
-except AttributeError:
-    if platform.system() != 'Windows':
-        warn('Unable to import jobs_posix.py.  Falling back to '
-             'jobs_not_implemented.py',
-             RuntimeWarning)
-
-    from xonsh.jobs_not_implemented import *
+if platform.system() == 'Windows':
+    from xonsh.jobs_windows import *
+else:
+    try:
+        from xonsh.jobs_posix import *
+    except AttributeError:
+        if platform.system() != 'Windows':
+            warn('Unable to import jobs_posix.py.  Falling back to '
+                 'jobs_not_implemented.py',
+                 RuntimeWarning)
+        from xonsh.jobs_not_implemented import *

--- a/xonsh/jobs_not_implemented.py
+++ b/xonsh/jobs_not_implemented.py
@@ -1,5 +1,6 @@
 
 from collections import namedtuple
+from subprocess import TimeoutExpired
 import builtins
 import os
 
@@ -26,7 +27,13 @@ def wait_for_active_job():
         return
     if _active_job['bg']:
         return
-    obj.wait()
+    while obj.returncode is None:
+        try:
+            obj.wait(0.01)
+        except TimeoutExpired:
+            pass
+        except KeyboardInterrupt:
+            obj.kill()
     obj.done = True
 
 

--- a/xonsh/jobs_not_implemented.py
+++ b/xonsh/jobs_not_implemented.py
@@ -4,7 +4,6 @@ import builtins
 import os
 
 
-
 ProcProxy = namedtuple('ProcProxy', ['stdout', 'stderr'])
 """
 A class representing a Python function to be run as a subprocess command.
@@ -17,6 +16,7 @@ def add_job(info):
     global _active_job
     _active_job = info
 
+
 def wait_for_active_job():
     global _active_job
     if _active_job is None:
@@ -24,21 +24,30 @@ def wait_for_active_job():
     obj = _active_job['obj']
     if isinstance(obj, ProcProxy):
         return
+    if _active_job['bg']:
+        return
     obj.wait()
     obj.done = True
-    
+
 
 def kill_all_jobs():
-    pass
+    if _active_job is not None:
+        try:
+            _active_jobs['obj'].kill()
+        except:
+            pass
 
 
 msg = 'Job control not implemented on this platform.\n'
 
+
 def jobs(args, stdin=None):
     return '', msg
 
+
 def fg(args, stdin=None):
     return '', msg
+
 
 def bg(args, stdin=None):
     return '', msg
@@ -46,4 +55,3 @@ def bg(args, stdin=None):
 
 def ignore_SIGTSTP():
     pass
-

--- a/xonsh/jobs_windows.py
+++ b/xonsh/jobs_windows.py
@@ -1,0 +1,187 @@
+"""
+Job control for the xonsh shell: Windows Version
+"""
+import os
+import sys
+import time
+import signal
+import builtins
+
+from collections import namedtuple
+from subprocess import TimeoutExpired
+
+ProcProxy = namedtuple('ProcProxy', ['stdout', 'stderr'])
+"""
+A class representing a Python function to be run as a subprocess command.
+"""
+
+
+def ignore_SIGTSTP():
+    pass
+
+
+def _clear_dead_jobs():
+    to_remove = set()
+    for num, job in builtins.__xonsh_all_jobs__.items():
+        obj = job['obj']
+        if isinstance(obj, ProcProxy) or obj.poll() is not None:
+            to_remove.add(num)
+    for i in to_remove:
+        del builtins.__xonsh_all_jobs__[i]
+        if builtins.__xonsh_active_job__ == i:
+            builtins.__xonsh_active_job__ = None
+    if builtins.__xonsh_active_job__ is None:
+        _reactivate_job()
+
+
+def _reactivate_job():
+    if len(builtins.__xonsh_all_jobs__) == 0:
+        return
+    builtins.__xonsh_active_job__ = max(builtins.__xonsh_all_jobs__.items(),
+                                        key=lambda x: x[1]['started'])[0]
+
+
+def print_one_job(num):
+    """Print a line describing job number ``num``."""
+    try:
+        job = builtins.__xonsh_all_jobs__[num]
+    except KeyError:
+        return
+    act = '*' if num == builtins.__xonsh_active_job__ else ' '
+    status = job['status']
+    cmd = [' '.join(i) if isinstance(i, list) else i for i in job['cmds']]
+    cmd = ' '.join(cmd)
+    pid = job['pids'][-1]
+    bg = ' &' if job['bg'] else ''
+    print('{}[{}] {}: {}{} ({})'.format(act, num, status, cmd, bg, pid))
+
+
+def get_next_job_number():
+    """Get the lowest available unique job number (for the next job created).
+    """
+    _clear_dead_jobs()
+    i = 1
+    while i in builtins.__xonsh_all_jobs__:
+        i += 1
+    return i
+
+
+def add_job(info):
+    """
+    Add a new job to the jobs dictionary.
+    """
+    info['started'] = time.time()
+    info['status'] = 'running'
+    num = get_next_job_number()
+    builtins.__xonsh_all_jobs__[num] = info
+    builtins.__xonsh_active_job__ = num
+    if info['bg']:
+        print_one_job(num)
+
+
+def _default_sigint_handler(num, frame):
+    raise KeyboardInterrupt
+
+
+def wait_for_active_job():
+    """
+    Wait for the active job to finish, to be killed by SIGINT, or to be
+    suspended by ctrl-z.
+    """
+    _clear_dead_jobs()
+    act = builtins.__xonsh_active_job__
+    if act is None:
+        return
+    job = builtins.__xonsh_all_jobs__[act]
+    obj = job['obj']
+    if isinstance(obj, ProcProxy):
+        return
+    if job['bg']:
+        return
+    while obj.returncode is None:
+        try:
+            obj.wait(0.01)
+        except TimeoutExpired:
+            pass
+        except KeyboardInterrupt:
+            obj.kill()
+    if obj.poll() is not None:
+        builtins.__xonsh_active_job__ = None
+
+
+def kill_all_jobs():
+    """
+    Send SIGKILL to all child processes (called when exiting xonsh).
+    """
+    _clear_dead_jobs()
+    for job in builtins.__xonsh_all_jobs__.values():
+        job['obj'].kill()
+
+
+def jobs(args, stdin=None):
+    """
+    xonsh command: jobs
+
+    Display a list of all current jobs.
+    """
+    _clear_dead_jobs()
+    for j in sorted(builtins.__xonsh_all_jobs__):
+        print_one_job(j)
+    return None, None
+
+
+def fg(args, stdin=None):
+    """
+    xonsh command: fg
+
+    Bring the currently active job to the foreground, or, if a single number is
+    given as an argument, bring that job to the foreground.
+    """
+    _clear_dead_jobs()
+    if len(args) == 0:
+        act = builtins.__xonsh_active_job__
+        if act is None:
+            return '', 'Cannot bring nonexistent job to foreground.\n'
+    elif len(args) == 1:
+        try:
+            act = int(args[0])
+        except ValueError:
+            return '', 'Invalid job: {}\n'.format(args[0])
+        if act not in builtins.__xonsh_all_jobs__:
+            return '', 'Invalid job: {}\n'.format(args[0])
+    else:
+        return '', 'fg expects 0 or 1 arguments, not {}\n'.format(len(args))
+    builtins.__xonsh_active_job__ = act
+    job = builtins.__xonsh_all_jobs__[act]
+    job['bg'] = False
+    job['status'] = 'running'
+    print_one_job(act)
+
+
+def bg(args, stdin=None):
+    """
+    xonsh command: bg
+
+    Resume execution of the currently active job in the background, or, if a
+    single number is given as an argument, resume that job in the background.
+    """
+    _clear_dead_jobs()
+    if len(args) == 0:
+        # start active job in foreground
+        act = builtins.__xonsh_active_job__
+        if act is None:
+            return '', 'Cannot send nonexistent job to background.\n'
+    elif len(args) == 1:
+        try:
+            act = int(args[0])
+        except ValueError:
+            return '', 'Invalid job: {}\n'.format(args[0])
+        if act not in builtins.__xonsh_all_jobs__:
+            return '', 'Invalid job: {}\n'.format(args[0])
+    else:
+        return '', 'bg expects 0 or 1 arguments, not {}\n'.format(len(args))
+    builtins.__xonsh_active_job__ = act
+    job = builtins.__xonsh_all_jobs__[act]
+    job['bg'] = True
+    job['status'] = 'running'
+    print_one_job(act)

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -2,14 +2,15 @@
 import os
 import sys
 import builtins
+import platform
 import traceback
 from cmd import Cmd
 from warnings import warn
 from argparse import Namespace
 
 from xonsh.execer import Execer
-from xonsh.tools import XonshError
 from xonsh.completer import Completer
+from xonsh.tools import XonshError, escape_windows_command_string
 from xonsh.environ import xonshrc_context, multiline_prompt, format_prompt
 
 RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
@@ -196,7 +197,11 @@ class Shell(Cmd):
         else:
             return
         t = format_prompt(t)
-        sys.stdout.write("\x1b]2;{0}\x07".format(t))
+        if platform.system() == 'Windows':
+            t = escape_windows_command_string(t)
+            os.system('title {}'.format(t))
+        else:
+            sys.stdout.write("\x1b]2;{0}\x07".format(t))
 
     @property
     def prompt(self):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -366,3 +366,13 @@ def suggestion_sort_helper(x, y):
     inx = len([i for i in x if i not in y])
     iny = len([i for i in y if i not in x])
     return lendiff + inx + iny
+
+
+def escape_windows_command_string(s):
+    s = s.replace('%','%%')
+    for c in ('^', '&', '<', '>', '|', "'", '`', ',', ';', '=', '(', ')'):
+        s = s.replace(c, '^' + c)
+    s = s.replace('!','^^!')
+    for c in ('[', ']', '.', '"', '.', '*', '?'):
+        s = s.replace(c, '\\' + c)
+    return s


### PR DESCRIPTION
I played around with this a bit on Windows, running directly from within `cmd`.  For me, `cmd` was having trouble with the window titles (the text was just being printed to the console, escape sequence and all).  I believe this should fix those issues.  Will include more comments in your original PR.
